### PR TITLE
added nuget feed for nuget.org seems to fix all the nuget restore issues

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,5 +2,6 @@
 <configuration>
     <packageSources>
         <add key="DSharpPlus (MyGet)" value="https://www.myget.org/F/dsharpplus-nightly/api/v3/index.json" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
The issue with building seems to really have been the nuget.org sources not sure why but I got it to restore the packages by changing this